### PR TITLE
GO-1554: create missing directories in install path

### DIFF
--- a/internal/installer/install.go
+++ b/internal/installer/install.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 )
 
@@ -121,6 +122,9 @@ func (id installData) install(tmpFile string, lookupFunc func() (string, error))
 		lookupFunc = func() (string, error) {
 			return exec.LookPath("contrast-go")
 		}
+	}
+	if err := os.MkdirAll(filepath.Dir(id.dst), 0755); err != nil {
+		return fmt.Errorf("installation directory issue: %w", err)
 	}
 	if err := os.Rename(tmpFile, id.dst); err != nil {
 		return err

--- a/internal/installer/install_test.go
+++ b/internal/installer/install_test.go
@@ -187,6 +187,10 @@ func Test_install(t *testing.T) {
 		"basic": {
 			tmpPresent: true,
 		},
+		"missing dir": {
+			tmpPresent: true,
+			dst:        filepath.Join(t.TempDir(), "dir", "contrast-go"),
+		},
 		"missing": {
 			tmpPresent:     false,
 			expectErr:      "no such file",

--- a/testdata/gopath.txt
+++ b/testdata/gopath.txt
@@ -10,10 +10,18 @@ stderr ^'Downloaded ''latest'''
 stderr 'to '$WORK/gopath/bin/contrast-go
 exists $WORK/gopath/bin/contrast-go
 
+env GOPATH=$WORK/gopath2
+env PATH=$GOPATH/bin:$PATH
+# don't initialize $GOPATH/bin. The installer should create it.
+contrast-go-installer -u $baseURL latest
+stderr ^'Downloaded ''latest'''
+stderr 'to '$GOPATH/bin/contrast-go
+exists $GOPATH/bin/contrast-go
+
 env GOBIN=
 env GOPATH=
 ! contrast-go-installer -u $baseURL latest
-stderr 'no such file or directory'
+stderr 'installation directory issue'
 
 env GOBIN=
 env GOPATH=$WORK/gopath


### PR DESCRIPTION
This change enhances the installer to create any missing directories in the contrast-go installation path. This allows the default behavior of installing to $GOPATH/bin to succeed when the bin directory doesn't existing under $GOPATH. It will also support other missing directories when a custom $GOBIN is set.