### PR TITLE
GO-591: bump copyright year, support native arm64 binaries

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2022 Contrast Security, Inc.
+Copyright 2023 Contrast Security, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/internal/installer/install.go
+++ b/internal/installer/install.go
@@ -55,14 +55,6 @@ func Install(baseURL, version, os, arch, path string) error {
 		dst:     path,
 	}
 	tmp, err := id.download()
-	if err != nil && id.os == "darwin" && id.arch == "arm64" {
-		// No darwin/arm64 binary? Try darwin/amd64. We don't do the same for
-		// linux/arm64 since linux doesn't automagically translate binaries.
-		if _, ok := err.(*errBadPlat); ok {
-			id.arch = "amd64"
-			tmp, err = id.download()
-		}
-	}
 	if err != nil {
 		return err
 	}
@@ -215,9 +207,9 @@ func (id installData) dlNotFoundError(res *http.Response) error {
 			return fmt.Errorf(badver, id.version)
 		}
 
-		return &errBadVersion{
-			availableVersions: avail,
-			badVersion:        id.version,
+		return &ErrBadVersion{
+			AvailableVersions: avail,
+			BadVersion:        id.version,
 		}
 	}
 
@@ -226,10 +218,10 @@ func (id installData) dlNotFoundError(res *http.Response) error {
 		return fmt.Errorf(unknownError)
 	}
 	// os and/or arch is invalid
-	return &errBadPlat{
-		available: avail,
-		arch:      id.arch,
-		os:        id.os,
+	return &ErrBadPlatform{
+		Available: avail,
+		Arch:      id.arch,
+		OS:        id.os,
 	}
 }
 
@@ -250,12 +242,12 @@ func listPlatforms(body io.Reader) ([]string, error) {
 	return plats, nil
 }
 
-type errBadPlat struct {
-	available []string
-	arch, os  string
+type ErrBadPlatform struct {
+	Available []string
+	Arch, OS  string
 }
 
-func (err *errBadPlat) Error() string {
+func (err *ErrBadPlatform) Error() string {
 	return fmt.Sprintf("contrast-go is not available for platform \"%s-%s\". Available platforms:\n\t%s\n%s",
-		err.os, err.arch, strings.Join(err.available, ", "), sysRequirementsPg)
+		err.OS, err.Arch, strings.Join(err.Available, ", "), sysRequirementsPg)
 }

--- a/internal/installer/install.go
+++ b/internal/installer/install.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Contrast Security, Inc.
+// Copyright 2023 Contrast Security, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -55,6 +55,14 @@ func Install(baseURL, version, os, arch, path string) error {
 		dst:     path,
 	}
 	tmp, err := id.download()
+	if err != nil && id.os == "darwin" && id.arch == "arm64" {
+		// No darwin/arm64 binary? Try darwin/amd64. We don't do the same for
+		// linux/arm64 since linux doesn't automagically translate binaries.
+		if _, ok := err.(*errBadPlat); ok {
+			id.arch = "amd64"
+			tmp, err = id.download()
+		}
+	}
 	if err != nil {
 		return err
 	}

--- a/internal/installer/install_test.go
+++ b/internal/installer/install_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Contrast Security, Inc.
+// Copyright 2023 Contrast Security, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/installer/version.go
+++ b/internal/installer/version.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Contrast Security, Inc.
+// Copyright 2023 Contrast Security, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/installer/version.go
+++ b/internal/installer/version.go
@@ -97,20 +97,20 @@ func (a versions) String() string {
 	return strings.Join(s, ", ")
 }
 
-type errBadVersion struct {
-	availableVersions versions
-	badVersion        string
+type ErrBadVersion struct {
+	AvailableVersions versions
+	BadVersion        string
 }
 
 const maxVersionsListed = 5
 
-func (err *errBadVersion) Error() string {
-	sort.Sort(err.availableVersions)
-	if len(err.availableVersions) > maxVersionsListed {
-		err.availableVersions = err.availableVersions[:maxVersionsListed]
+func (err *ErrBadVersion) Error() string {
+	sort.Sort(err.AvailableVersions)
+	if len(err.AvailableVersions) > maxVersionsListed {
+		err.AvailableVersions = err.AvailableVersions[:maxVersionsListed]
 	}
 	return fmt.Sprintf("Version %q does not exist. Available versions include\n\t%s\n%s",
-		err.badVersion, err.availableVersions.String(), agentArchivePg)
+		err.BadVersion, err.AvailableVersions.String(), agentArchivePg)
 }
 
 // reads html from body, returning extracted versions

--- a/internal/installer/version_test.go
+++ b/internal/installer/version_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Contrast Security, Inc.
+// Copyright 2023 Contrast Security, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/installer/version_test.go
+++ b/internal/installer/version_test.go
@@ -99,9 +99,9 @@ func TestErrBadVersion_Error(t *testing.T) {
 		avail = append(avail, toVersion(v))
 	}
 
-	err := &errBadVersion{
-		availableVersions: avail,
-		badVersion:        "badVer",
+	err := &ErrBadVersion{
+		AvailableVersions: avail,
+		BadVersion:        "badVer",
 	}
 	got := err.Error()
 	if !strings.Contains(got, want) {

--- a/license_test.go
+++ b/license_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Contrast Security, Inc.
+// Copyright 2023 Contrast Security, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Contrast Security, Inc.
+// Copyright 2023 Contrast Security, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -115,8 +115,6 @@ func main1() int {
 	}
 	path = filepath.Join(path, "contrast-go")
 
-	fixDarwinArch(env)
-
 	if err := installer.Install(*source, version, env.GOOS, env.GOARCH, path); err != nil {
 		log.Println(err)
 		return 2
@@ -154,16 +152,4 @@ func targetDir(gobin, path string) (string, error) {
 	}
 
 	return filepath.Join(list[0], "bin"), nil
-}
-
-func fixDarwinArch(env *goenv) {
-	if !(env.GOOS == "darwin" && env.GOARCH == "arm64") {
-		return
-	}
-
-	env.GOARCH = "amd64"
-	log.Println(
-		"darwin/arm64 is not currently a release target.",
-		"Setting release to darwin/amd64 to run in compatibility mode.",
-	)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Contrast Security, Inc.
+// Copyright 2023 Contrast Security, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -113,6 +113,16 @@ const (
 <pre>Name              Last modified      Size</pre><hr/>
 <pre><a href="../">../</a>
 <a href="darwin-amd64/">darwin-amd64/</a>      07-Jul-2022 15:47    -
+<a href="darwin-arm64/">darwin-arm64/</a>      07-Jul-2022 15:47    -
+<a href="linux-amd64/">linux-amd64/</a>       07-Jul-2022 15:47    -
+<a href="dependencies.csv">dependencies.csv</a>   07-Jul-2022 15:47  1.25 KB
+</pre><hr/><address style="font-size:small;">Online Server</address></body></html>`
+
+	archdirNoArm = `<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+<html><body><h1>Index of go-agent-release/1.2.3</h1>
+<pre>Name              Last modified      Size</pre><hr/>
+<pre><a href="../">../</a>
+<a href="darwin-amd64/">darwin-amd64/</a>      07-Jul-2022 15:47    -
 <a href="linux-amd64/">linux-amd64/</a>       07-Jul-2022 15:47    -
 <a href="dependencies.csv">dependencies.csv</a>   07-Jul-2022 15:47  1.25 KB
 </pre><hr/><address style="font-size:small;">Online Server</address></body></html>`
@@ -120,7 +130,7 @@ const (
 
 var (
 	allowedOses   = []string{"linux", "darwin"}
-	allowedArches = []string{"amd64"}
+	allowedArches = []string{"amd64", "arm64"}
 )
 
 func allowed(list []string, val string) bool {
@@ -151,6 +161,8 @@ func startServer(ts *testscript.TestScript, neg bool, args []string) {
 				return
 			case "3.0.0":
 				_, _ = w.Write([]byte(archdir))
+			case "1.2.3":
+				_, _ = w.Write([]byte(archdirNoArm))
 			default:
 				w.WriteHeader(404)
 			}
@@ -162,7 +174,13 @@ func startServer(ts *testscript.TestScript, neg bool, args []string) {
 				w.WriteHeader(404)
 				return
 			}
-			if !allowed(allowedArches, osArch[1]) {
+			arches := allowedArches
+			if paths[0] != "latest" && paths[0] != "3.0.0" {
+				// only later revisions have native arm64 binaries
+				arches = []string{"amd64"}
+			}
+
+			if !allowed(arches, osArch[1]) {
 				w.WriteHeader(404)
 				return
 			}

--- a/testdata/basic.txt
+++ b/testdata/basic.txt
@@ -10,9 +10,14 @@ env GOARCH=amd64
 contrast-go-installer -u $baseURL 1.2.3
 grep '/1.2.3/linux-amd64/contrast-go' $GOBIN/contrast-go
 
-# expect that darwin/arm64 gets corrected to darwin/amd64
+# expect that darwin/arm64 is not changed to darwin/amd64 when arm64 release exists
 env GOOS=darwin
 env GOARCH=arm64
 contrast-go-installer -u $baseURL latest
-stderr ^'darwin/arm64 is not currently a release target'
-grep '/latest/darwin-amd64/contrast-go' $GOBIN/contrast-go
+grep '/latest/darwin-arm64/contrast-go' $GOBIN/contrast-go
+
+# expect that darwin/arm64 is changed to darwin/amd64 when arm64 release does not exist
+env GOOS=darwin
+env GOARCH=arm64
+contrast-go-installer -u $baseURL 1.2.3
+grep '/1.2.3/darwin-amd64/contrast-go' $GOBIN/contrast-go

--- a/testdata/basic.txt
+++ b/testdata/basic.txt
@@ -20,4 +20,5 @@ grep '/latest/darwin-arm64/contrast-go' $GOBIN/contrast-go
 env GOOS=darwin
 env GOARCH=arm64
 contrast-go-installer -u $baseURL 1.2.3
+stderr ^'darwin/arm64 is not a release target for this'
 grep '/1.2.3/darwin-amd64/contrast-go' $GOBIN/contrast-go

--- a/testdata/unsupported.txt
+++ b/testdata/unsupported.txt
@@ -13,12 +13,12 @@ env GOOS=linux
 env GOARCH=and64
 ! contrast-go-installer -u $baseURL latest
 stderr 'contrast-go is not available for platform "linux-and64".'
-stderr 'darwin-amd64, linux-amd64'
+stderr 'darwin-amd64, darwin-arm64, linux-amd64'
 ! exists $GOBIN/contrast-go
 
 env GOOS=darfin
 env GOARCH=amd64
 ! contrast-go-installer -u $baseURL latest
 stderr 'contrast-go is not available for platform "darfin-amd64".'
-stderr 'darwin-amd64, linux-amd64'
+stderr 'darwin-amd64, darwin-arm64, linux-amd64'
 ! exists $GOBIN/contrast-go


### PR DESCRIPTION
This adds support for darwin/arm64 and linux/arm64. 

In addition, for darwin/arm64: if the native binary is not available it will try darwin/amd64 instead, taking advantage of OSX's ability to run amd64 binaries on arm.