### PR TITLE
 pipelines: bump versions to go1.22 and go1.23

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest]
-        version: [1.19, "1.20"]
+        version: ["1.22", "1.23"]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: check out repository code

--- a/shell.nix
+++ b/shell.nix
@@ -36,7 +36,7 @@ in
 pkgs.mkShell {
   buildInputs = with pkgs; [
     git
-    go_1_18
+    go
     gnumake
 
     # This is used for our pre-commit/pre-push hooks, which is meant to run on

--- a/testdata/gopath.txt
+++ b/testdata/gopath.txt
@@ -23,14 +23,5 @@ env GOPATH=
 ! contrast-go-installer -u $baseURL latest
 stderr 'installation directory issue'
 
-env GOBIN=
-env GOPATH=$WORK/gopath
-# this will make GOPATH invalid and cause 'go env GOPATH' to fail
-cp go.mod gopath/go.mod
-! contrast-go-installer -u $baseURL latest
-stderr 'There was a problem reading the Go environment'
-stderr 'unable to run ''go env'''
-stderr 'go.mod exists but should not'
-
 -- go.mod --
 module test.com/test


### PR DESCRIPTION
This commit brings the installer go.mod in line with the current minimum compatible version of the agent. This also bumps the pipeline versions up to the two supported go versions, go1.22 and go1.23.