### PR TITLE
pipelines: pin actions/checkout action to commit hash

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - name: check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: set up Go
         uses: actions/setup-go@v5


### PR DESCRIPTION
Currently, `actions/checkout` is pinned to `v4`.
We should pin the action to a specific commit to comply with company policy. This should not be an upgrade or downgrade: the v4 tag and v4.2.2 currently both refer to the same commit hash.