### PR TITLE
pipelines: pin actions/setup-go action to commit hash

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@6c1fd22b67f7a7c42ad9a45c0f4197434035e429 # v5
         with:
           go-version: ${{ matrix.version }}
           cache: true


### PR DESCRIPTION
While we are still waiting for official approval for the `setup-go` action, we should still pin the action to a specific commit hash in preparation for approval. Currently, the v5 tag points to v5.3.0, so this is a version downgrade, but this is the commit we asked labs for approval.