### PR TITLE
actions/setup-go: bump to 5.3.0, use full version

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: set up Go
-        uses: actions/setup-go@6c1fd22b67f7a7c42ad9a45c0f4197434035e429 # v5
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           go-version: ${{ matrix.version }}
           cache: true


### PR DESCRIPTION
Dependabot wanted to upgrade this to the hash corresponding to HEAD, rather than a release version. This change updates us to the latest approved version and updates the trailing comment to the major.minor.patch format.